### PR TITLE
Cache state in StateStore and use cached access

### DIFF
--- a/store.py
+++ b/store.py
@@ -14,16 +14,26 @@ class StateStore:
         self.state_path = self.dir / "state.json"
         self.backup_dir = self.dir / "backups"
         self.backup_dir.mkdir(parents=True, exist_ok=True)
+        self._state: dict | None = None
 
     def load(self) -> Dict[str, Any]:
         if self.state_path.exists():
             return json.loads(self.state_path.read_text(encoding="utf-8"))
         return {}
 
+    def get_state(self) -> Dict[str, Any]:
+        if self._state is None:
+            self._state = self.load()
+        return self._state
+
     def save(self, st: Dict[str, Any]):
         tmp = self.dir / "state.tmp"
         tmp.write_text(json.dumps(st, ensure_ascii=False, indent=2), encoding="utf-8")
         tmp.replace(self.state_path)
+
+    def update_state(self, st: Dict[str, Any]):
+        self._state = st
+        self.save(st)
 
     def backup(self) -> str:
         if not self.state_path.exists():


### PR DESCRIPTION
## Summary
- Add cached `_state` to `StateStore` with `get_state` and `update_state`
- Update game logic to retrieve state via cache and persist changes with `update_state`

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689bf2f9ed3c8326a5ef733f42517c82